### PR TITLE
Hotfix for backtesting history observer 

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "OptiPie TradingView Optimizer",
   "description": "TradingView Parameter Optimizer as an extension",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "manifest_version": 3,
   "icons": {
     "16": "images/icons/optipie16.png",

--- a/script.js
+++ b/script.js
@@ -204,7 +204,7 @@ async function OptimizeParams(userInputs, tvParameterIndex, optimizationResults)
             });
         });
 
-        var element = document.querySelector("div[class*=backtesting-content-wrapper]")
+        var element = document.querySelector("div[class*=backtesting][class*=deep-history]")
         let options = {
             childList: true,
             subtree: true,


### PR DESCRIPTION
Fixing the empty mutation observer selector due to updates made on Tradingview 